### PR TITLE
Add data collection permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,8 +11,12 @@
   ],
   "content_scripts": [
     {
-      "matches": ["https://www.wanikani.com/*"],
-      "js": ["content.js"],
+      "matches": [
+        "https://www.wanikani.com/*"
+      ],
+      "js": [
+        "content.js"
+      ],
       "run_at": "document_idle"
     }
   ],
@@ -25,7 +29,12 @@
   },
   "browser_specific_settings": {
     "gecko": {
-      "id": "wanikani-font-randomizer@moz-addon.com"
+      "id": "wanikani-font-randomizer@moz-addon.com",
+      "data_collection_permissions": {
+        "required": [
+          "none"
+        ]
+      }
     },
     "gecko_android": {}
   }


### PR DESCRIPTION
Adds the missing parameter to the manifest. I interpret data collection as sending data to a server and storing it. Since this extension does not do this I set the required permissions to "none".